### PR TITLE
fix: #28 - Resolve Jest/Expo compatibility issues for SDK 53

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,5 +23,14 @@ module.exports = {
   coverageDirectory: '<rootDir>/coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   clearMocks: true,
-  resetMocks: true
+  resetMocks: true,
+  modulePathIgnorePatterns: [
+    '<rootDir>/amplify/#current-cloud-backend/',
+    '<rootDir>/amplify-backup/',
+    '<rootDir>/amplify/.*/node_modules/',
+    '<rootDir>/amplify-backup/.*/node_modules/'
+  ],
+  globals: {
+    __DEV__: true
+  }
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,22 @@
 // Jest setup file
 
+// Global mocks for React Native and Expo
+global.__DEV__ = true;
+
+// Mock Expo import meta registry before any imports
+global.__ExpoImportMetaRegistry = {};
+
+// Mock expo-modules-core before other modules
+jest.mock('expo-modules-core', () => ({
+  NativeModulesProxy: {},
+  EventEmitter: jest.fn(),
+  createWebModule: jest.fn(),
+  requireNativeModule: jest.fn(() => ({})),
+}));
+
+// Mock Expo winter runtime to prevent import errors
+jest.mock('expo/src/winter/runtime.native', () => ({}), { virtual: true });
+
 // Mock Expo modules
 jest.mock('expo-status-bar', () => ({
   StatusBar: 'StatusBar',
@@ -111,3 +128,13 @@ beforeAll(() => {
 afterAll(() => {
   console.warn = originalWarn;
 });
+
+// Mock Metro configuration
+jest.mock('expo/metro-config', () => ({
+  getDefaultConfig: jest.fn(() => ({
+    resolver: {},
+    transformer: {},
+    serializer: {},
+    server: {},
+  })),
+}));


### PR DESCRIPTION
Closes #28

## Summary
- Fixed Jest/Expo compatibility issues that prevented tests from running after implementing testing infrastructure
- Resolved module resolution errors for expo-modules-core and Expo winter runtime
- Fixed Haste module naming collisions for Amplify function directories

## Changes
1. **Jest Configuration Updates** (`jest.config.js`):
   - Added `modulePathIgnorePatterns` to exclude Amplify directories from Haste module system
   - Added `globals.__DEV__` configuration for React Native compatibility

2. **Enhanced Test Setup** (`jest.setup.js`):
   - Added global `__ExpoImportMetaRegistry` mock for Expo SDK 53 compatibility
   - Enhanced expo-modules-core mock with `requireNativeModule` function
   - Added virtual mock for Expo winter runtime to prevent import scope errors

## Related Issues
- Related to PR #27 which added the testing infrastructure
- Unblocks issues #23-26 for adding comprehensive tests

## Testing
- ✅ Tests now run without module resolution errors
- ✅ No more Haste naming collision warnings
- ✅ All test infrastructure is working correctly
- ✅ Sample tests execute successfully (some fail due to test logic, not infrastructure)

## Before/After
**Before:**
```
Cannot find module 'expo-modules-core/src/Refs'
jest-haste-map: Haste module naming collision: CreateSampleRecord
ReferenceError: You are trying to `import` a file outside of the scope of the test code
```

**After:**
```
Test Suites: 2 failed, 2 passed, 4 total
Tests:       4 failed, 25 passed, 29 total
```

## Checklist
- [x] Tests run successfully without infrastructure errors
- [x] Code follows project conventions
- [x] No changes to application code (only test configuration)
- [x] Checked for conflicts with other open issues

🤖 Generated with [Claude Code](https://claude.ai/code)