### PR TITLE
fix: #30 - Resolve failing tests in FormButton and Dimensions test suites

### DIFF
--- a/src/components/__tests__/FormButton.test.js
+++ b/src/components/__tests__/FormButton.test.js
@@ -24,11 +24,11 @@ describe('FormButton Component', () => {
   });
 
   test('applies correct styles', () => {
-    const { getByText } = render(
-      <FormButton buttonTitle="Styled Button" />
+    const { getByTestId } = render(
+      <FormButton buttonTitle="Styled Button" testID="styled-button" />
     );
     
-    const button = getByText('Styled Button').parent;
+    const button = getByTestId('styled-button');
     
     expect(button.props.style).toMatchObject({
       backgroundColor: '#69FAA0',
@@ -40,7 +40,7 @@ describe('FormButton Component', () => {
   });
 
   test('passes additional props to TouchableOpacity', () => {
-    const { getByText } = render(
+    const { getByTestId } = render(
       <FormButton 
         buttonTitle="Test Button" 
         testID="form-button"
@@ -49,7 +49,7 @@ describe('FormButton Component', () => {
       />
     );
     
-    const button = getByText('Test Button').parent;
+    const button = getByTestId('form-button');
     
     expect(button.props.testID).toBe('form-button');
     expect(button.props.accessible).toBe(true);

--- a/src/utils/__tests__/Dimensions.test.js
+++ b/src/utils/__tests__/Dimensions.test.js
@@ -1,32 +1,44 @@
-import { windowWidth, windowHeight } from '../Dimensions';
-import { Dimensions } from 'react-native';
-
-jest.mock('react-native', () => ({
-  Dimensions: {
-    get: jest.fn().mockReturnValue({ width: 375, height: 812 }),
-  },
-}));
-
+// Test the Dimensions utility
 describe('Dimensions Utils', () => {
+  let Dimensions;
+  
   beforeEach(() => {
-    jest.clearAllMocks();
+    // Clear all module caches
+    jest.resetModules();
+    
+    // Mock react-native module
+    jest.doMock('react-native', () => ({
+      Dimensions: {
+        get: jest.fn().mockReturnValue({ width: 375, height: 812 }),
+      },
+    }));
+    
+    // Get reference to mocked Dimensions
+    Dimensions = require('react-native').Dimensions;
+  });
+
+  afterEach(() => {
+    jest.dontMock('react-native');
   });
 
   test('should export window dimensions', () => {
+    const { windowWidth, windowHeight } = require('../Dimensions');
     expect(windowWidth).toBe(375);
     expect(windowHeight).toBe(812);
   });
 
   test('should call Dimensions.get with window parameter', () => {
+    // Import the module which will trigger Dimensions.get calls
+    require('../Dimensions');
     expect(Dimensions.get).toHaveBeenCalledWith('window');
+    expect(Dimensions.get).toHaveBeenCalledTimes(2); // Called twice for width and height
   });
 
   test('should handle different screen sizes', () => {
     // Mock different screen size
-    Dimensions.get.mockReturnValueOnce({ width: 414, height: 896 });
+    Dimensions.get.mockReturnValue({ width: 414, height: 896 });
     
     // Re-import to get new values
-    jest.resetModules();
     const { windowWidth: newWidth, windowHeight: newHeight } = require('../Dimensions');
     
     expect(newWidth).toBe(414);


### PR DESCRIPTION
Closes #30

## Changes
- Fixed FormButton component tests by using `getByTestId` instead of accessing `.parent` from Text elements
- Fixed Dimensions utility tests by properly mocking the react-native module before imports using `jest.doMock`
- All 29 tests now pass successfully

## Related Issues
- This issue was blocking issues #23-26 (comprehensive testing features)
- No conflicts with other open issues discovered during analysis

## Testing
- Ran `npm test` to verify all tests pass
- Tested individual test suites: `npm test -- src/components/__tests__/FormButton.test.js` and `npm test -- src/utils/__tests__/Dimensions.test.js`
- All 29 tests pass without errors

## Checklist
- [x] Tests pass
- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] Checked for conflicts with other open issues