### PR TITLE
Fix: Grant Lambda permissions to run ECS tasks

### DIFF
--- a/amplify/backend/custom/ecs/audio-processing/Dockerfile
+++ b/amplify/backend/custom/ecs/audio-processing/Dockerfile
@@ -21,7 +21,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY audio_processor.py .
+COPY s3_operations.py .
 COPY entrypoint.sh .
+COPY utils/ ./utils/
 
 # Make entrypoint executable and set proper ownership
 RUN chmod +x entrypoint.sh && chown -R audioprocess:audioprocess /app

--- a/amplify/backend/custom/ecsAudioProcessing/ecsAudioProcessing-cloudformation-template.json
+++ b/amplify/backend/custom/ecsAudioProcessing/ecsAudioProcessing-cloudformation-template.json
@@ -819,6 +819,79 @@
           }
         ]
       }
+    },
+    "LambdaECSPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "DependsOn": [
+        "AudioProcessingCluster",
+        "ECSTaskDefinition",
+        "ECSTaskExecutionRole",
+        "ECSTaskRole"
+      ],
+      "Properties": {
+        "PolicyName": {
+          "Fn::Sub": "LambdaECSPolicy-${env}"
+        },
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ecs:RunTask"
+              ],
+              "Resource": {
+                "Fn::Sub": "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/little-bit-audio-processing-${env}:*"
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "iam:PassRole"
+              ],
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ECSTaskExecutionRole",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::GetAtt": [
+                    "ECSTaskRole", 
+                    "Arn"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Fn::Select": [
+              1,
+              {
+                "Fn::Split": [
+                  "/",
+                  {
+                    "Fn::Select": [
+                      5,
+                      {
+                        "Fn::Split": [
+                          ":",
+                          {
+                            "Ref": "functionCreateSampleRecordLambdaExecutionRoleArn"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   "Outputs": {


### PR DESCRIPTION
## Summary
- Adds IAM policy to allow Lambda functions to trigger ECS tasks
- Updates Dockerfile to include all required Python modules
- Fixes AccessDenied errors in the audio processing pipeline

## Changes
- CloudFormation template: Added LambdaECSPolicy resource
- Dockerfile: Added COPY statements for s3_operations.py and utils/

## Test Plan
- [x] Container builds successfully
- [x] Container pushed to ECR
- [x] Lambda can now trigger ECS tasks without AccessDenied errors
- [ ] End-to-end audio processing (code fixes needed)

🤖 Generated with Claude Code