### PR TITLE
fix: #79 - User sounds not loading due to missing file field in GraphQL query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,4 +6,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - The AWS region is us-west-2
 
-[Rest of the existing content remains unchanged...]
+## GraphQL Query Generation
+
+**Important**: The auto-generated GraphQL queries in `src/graphql/queries.js` have a known issue where the `listSamples` query doesn't include the `file` field. This field is necessary for loading S3 URLs for audio playback.
+
+### The Issue
+- When running `amplify push` or `amplify codegen`, the queries are regenerated
+- The auto-generated `listSamples` query omits the nested `file` object field
+- Without this field, sounds cannot be loaded in the app
+
+### The Solution
+We use custom GraphQL queries in `src/graphql/customQueries.js` that include all necessary fields. These custom queries:
+- Are not overwritten by Amplify codegen
+- Include the complete field structure needed by the app
+- Should be used instead of the auto-generated queries where needed
+
+### Current Custom Queries
+- `listSamplesWithFile` - Used in `src/api/sounds.js` to fetch user sounds with S3 file information
+
+When adding new features that require GraphQL queries with nested fields, consider creating custom queries if the auto-generated ones are incomplete.

--- a/src/api/__tests__/sounds.test.js
+++ b/src/api/__tests__/sounds.test.js
@@ -14,6 +14,10 @@ jest.mock('../../graphql/queries', () => ({
   listSamples: 'mock-list-samples-query'
 }));
 
+jest.mock('../../graphql/customQueries', () => ({
+  listSamplesWithFile: 'mock-list-samples-with-file-query'
+}));
+
 jest.mock('../../graphql/subscriptions', () => ({
   onCreateSample: 'mock-on-create-sample-subscription'
 }));

--- a/src/api/sounds.js
+++ b/src/api/sounds.js
@@ -2,6 +2,7 @@ import { getUrl } from "aws-amplify/storage";
 import { generateClient } from "aws-amplify/api";
 import * as subscriptions from "../graphql/subscriptions";
 import * as queries from "../graphql/queries";
+import * as customQueries from "../graphql/customQueries";
 
 const client = generateClient();
 
@@ -21,7 +22,7 @@ const listUserSounds = async (userID) => {
     }
 
     const sounds = await client.graphql({
-      query: queries.listSamples,
+      query: customQueries.listSamplesWithFile,
       variables: {
         filter: {
           user_id: { eq: userID }

--- a/src/graphql/customQueries.js
+++ b/src/graphql/customQueries.js
@@ -1,0 +1,37 @@
+/* Custom GraphQL queries that won't be overwritten by Amplify codegen */
+
+export const listSamplesWithFile = /* GraphQL */ `
+  query ListSamples(
+    $filter: ModelSampleFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listSamples(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        name
+        user_id
+        file {
+          bucket
+          key
+          region
+          __typename
+        }
+        processing_status
+        processing_started_at
+        processing_completed_at
+        processing_error
+        processing_params
+        createdAt
+        updatedAt
+        _version
+        _deleted
+        _lastChangedAt
+        __typename
+      }
+      nextToken
+      startedAt
+      __typename
+    }
+  }
+`;


### PR DESCRIPTION
Closes #79

## Changes
- Created `src/graphql/customQueries.js` with `listSamplesWithFile` query that includes the file field
- Updated `src/api/sounds.js` to use the custom query instead of the auto-generated one
- Updated tests to mock the new custom query module
- Documented the issue and solution in `CLAUDE.md` for future reference

## Problem
The auto-generated `listSamples` GraphQL query was missing the `file` field, which contains the S3 object information (bucket, key, region). Without this field, the `getSound()` function in `src/api/sounds.js` returns early and no S3 URL is generated for audio playback, causing the sounds list to appear empty.

## Solution
Since the GraphQL queries are auto-generated by Amplify and get overwritten with each `amplify push` or `amplify codegen`, I created a custom query that includes all necessary fields. This custom query:
- Is not overwritten by Amplify codegen
- Includes the complete field structure needed by the app
- Provides a pattern for handling similar issues in the future

## Related Issues
- This fix unblocks issue #58 (Add audio progress bar) - sounds need to load for progress bars to work
- This fix unblocks issue #59 (Add sorting/filtering to sounds list) - sounds need to load to be sorted/filtered
- Related to issue #52 (S3 Audio File Integration) - overall audio file handling

## Testing
- All existing tests pass
- Tested with `npm test -- Sound` (46 tests passing)
- Manual testing would verify sounds load and play correctly in the app

## Checklist
- [x] Tests pass
- [x] Code follows project conventions
- [x] Documentation updated (CLAUDE.md)
- [x] Checked for conflicts with other open issues

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>